### PR TITLE
Formalise JSON-LD formatting

### DIFF
--- a/definitions/context.jsonld
+++ b/definitions/context.jsonld
@@ -1,13 +1,14 @@
 {
   "@context": {
-    "name": "http://schema.org/name",
-    "location": "http://schema.org/location",
-    "storageAccount": "https://your.org/ns#StorageAccount",
-    "sku": {
-      "@id": "https://your.org/ns#sku",
-      "@type": "@id"
-    },
-    "accessTier": "https://your.org/ns#accessTier",
-    "replication": "https://your.org/ns#replication"
+    "az": "https://example.com/azure#",
+    "az:StorageAccount": "https://example.com/azure#StorageAccount",
+    "az:name": "https://example.com/azure#name",
+    "az:sku": "https://example.com/azure#sku",
+    "az:tier": "https://example.com/azure#tier",
+    "az:accessTier": "https://example.com/azure#accessTier",
+    "az:accountReplication": "https://example.com/azure#accountReplication",
+    "az:publicNetworkAccess": "https://example.com/azure#publicNetworkAccess",
+    "az:allowBlobPublicAccess": "https://example.com/azure#allowBlobPublicAccess",
+    "az:blobSoftDeleteRetentionDays": "https://example.com/azure#blobSoftDeleteRetentionDays"
   }
 }

--- a/definitions/storage_account.jsonld
+++ b/definitions/storage_account.jsonld
@@ -1,14 +1,16 @@
 {
-  "@context": "./context.jsonld",
-  "@id": "urn:example:storage-account:uksouth:demo",
-  "@type": "storageAccount",
-  "name": "strdfstorage",
-  "sku": {
-    "tier": "Standard"
+  "@context": {
+    "az": "https://example.com/azure#"
   },
-  "accessTier": "Cool",
-  "accountReplication": "LRS",
-  "publicNetworkAccess": false,
-  "allowBlobPublicAccess": false,
-  "blobSoftDeleteRetentionDays": 7
+  "@id": "urn:example:storage-account:uksouth:demo",
+  "@type": "az:StorageAccount",
+  "az:name": "strdfstorage",
+  "az:sku": {
+    "az:tier": "Standard"
+  },
+  "az:accessTier": "Cool",
+  "az:accountReplication": "LRS",
+  "az:publicNetworkAccess": false,
+  "az:allowBlobPublicAccess": false,
+  "az:blobSoftDeleteRetentionDays": 7
 }

--- a/tooling/ingest.py
+++ b/tooling/ingest.py
@@ -21,14 +21,14 @@ def load_definition(path: Path) -> dict:
 
 def extract_storage_account(defn: dict) -> dict:
     sa = {}
-    sa['name'] = defn.get('name')
-    sku = defn.get('sku') or {}
-    sa['sku_tier'] = sku.get('tier')
-    sa['access_tier'] = defn.get('accessTier')
-    sa['accountReplication'] = defn.get('accountReplication')
-    sa['publicNetworkAccess'] = defn.get('publicNetworkAccess')
-    sa['allowBlobPublicAccess'] = defn.get('allowBlobPublicAccess')
-    sa['blobSoftDeleteRetentionDays'] = defn.get('blobSoftDeleteRetentionDays')
+    sa['name'] = defn.get('az:name')
+    sku = defn.get('az:sku') or {}
+    sa['sku_tier'] = sku.get('az:tier')
+    sa['access_tier'] = defn.get('az:accessTier')
+    sa['accountReplication'] = defn.get('az:accountReplication')
+    sa['publicNetworkAccess'] = defn.get('az:publicNetworkAccess')
+    sa['allowBlobPublicAccess'] = defn.get('az:allowBlobPublicAccess')
+    sa['blobSoftDeleteRetentionDays'] = defn.get('az:blobSoftDeleteRetentionDays')
 
     # Require at least name, sku_tier and accountReplication
     required = [k for k in ('name', 'sku_tier', 'accountReplication') if not sa.get(k)]


### PR DESCRIPTION
This pull request updates the Azure storage account definitions to use a new namespace and property naming convention, improving consistency and clarity across the codebase. The changes affect the JSON-LD context, the storage account definition file, and the ingestion logic in Python.

**Namespace and property naming standardization:**

* Updated the JSON-LD context in `definitions/context.jsonld` to use the `az:` namespace and new property names, replacing previous schema.org and custom URLs.
* Refactored `definitions/storage_account.jsonld` to use the inline `az:` context and updated all property names to the new `az:` format.

**Code and ingestion logic updates:**

* Modified the `extract_storage_account` function in `tooling/ingest.py` to extract values using the new `az:` property names, ensuring compatibility with the updated definition files.